### PR TITLE
Update single entry stream API docs

### DIFF
--- a/src/main/kotlin/cash/atto/node/account/entry/AccountEntryController.kt
+++ b/src/main/kotlin/cash/atto/node/account/entry/AccountEntryController.kt
@@ -44,7 +44,8 @@ import java.math.BigDecimal
 @Conditional(NotVoterCondition::class)
 @Tag(
     name = "Account Entries",
-    description = "A user-friendly view of account activity. Recommended for displaying transaction history in UIs.",
+    description = "A user-friendly view of account activity. Recommended for displaying transaction history in UIs.\n\n"
+    +   "Because a transaction's hash can be known before posting it, the ability to track its confirmation status by streaming a single entry is provided.",
 )
 class AccountEntryController(
     val repository: AccountEntryRepository,


### PR DESCRIPTION
It may not be immediately apparent why accessing an entry by hash uses an endpoint that ends in `/stream`. The reason for this is that it may be useful for a payment processor to watch a hash before the entry has been posted, waiting for it to get confirmed.

This commit clarifies why entries are streamable, rather than always downloading instantly like `/accounts/{publicKey}` does.

atto://ad7z3jdoeqwayzpaiafizb5su6zc2fyvbeg2wq5t3yfj3q5iuprx23z437juk